### PR TITLE
fix missing object CityInfo in exercises

### DIFF
--- a/RTutorial_Intro2/RTutorial_Intro2.Rmd
+++ b/RTutorial_Intro2/RTutorial_Intro2.Rmd
@@ -89,7 +89,11 @@ Recalling what we learned about subsetting dataframes, try to complete the follo
 
 1. Select the `Year` column.
 
-```{r exercise1-1, exercise = TRUE}
+```{r prepare-cityinfo, include=FALSE}
+CityInfo  <- read.csv("https://maddiebrown.github.io/ANTH630/data/Cityinfo.csv")
+```
+
+```{r exercise1-1, exercise = TRUE, exercise.setup="prepare-cityinfo"}
 
 ```
 
@@ -108,7 +112,7 @@ grade_result(
 
 2. Select the 5th element of the `Year` column.
 
-```{r exercise1-2, exercise = TRUE}
+```{r exercise1-2, exercise = TRUE, exercise.setup="prepare-cityinfo"}
 ```
 
 ```{r exercise1-2-solution}
@@ -121,7 +125,7 @@ grade_code("Excellent!")
 
 3. Select the 5th row of the `CityInfo` dataframe.
 
-```{r exercise1-3, exercise = TRUE}
+```{r exercise1-3, exercise = TRUE, exercise.setup="prepare-cityinfo"}
 ```
 
 ```{r exercise1-3-solution}
@@ -134,7 +138,7 @@ grade_code("Excellent!")
 
 4. Select the 5th and 6th rows.
 
-```{r exercise1-4, exercise = TRUE}
+```{r exercise1-4, exercise = TRUE, exercise.setup="prepare-cityinfo"}
 ```
 
 ```{r exercise1-4-solution}
@@ -204,7 +208,7 @@ Some basics with regular expressions:
 
 1. Select all city names starting with "s".
 
-```{r exercise2-1, exercise = TRUE}
+```{r exercise2-1, exercise = TRUE, exercise.setup="prepare-cityinfo"}
 
 ```
 
@@ -224,7 +228,7 @@ grade_result(
 
 2. Print all city names for cities founded in the 1600s or 1700s
 
-```{r exercise2-2, exercise = TRUE}
+```{r exercise2-2, exercise = TRUE, exercise.setup="prepare-cityinfo"}
 
 ```
 
@@ -241,7 +245,7 @@ grade_result(
 
 3. Print the name and year of founding for all cities with either "as" or "il" in the name.
 
-```{r exercise2-3, exercise = TRUE}
+```{r exercise2-3, exercise = TRUE, exercise.setup="prepare-cityinfo"}
 
 ```
 


### PR DESCRIPTION
Issue: https://github.com/UjjayiniDas/ANTHROPOLOGY_R_TUTORIALS/issues/2

This should fix the missing object error for the exercises in RTutorial_Intro2.

(I included the below explanation in the issue too)

Solution:
 use exercise.setup to provide the CityInfo object for the exercises.

Explanation:
The exercise chunks have their own R session, apart from the rest of the tutorial. So, they don't know about objects that were stored in previous code chunks. See https://rstudio.github.io/learnr/articles/exercises.html#exercise-setup and https://community.rstudio.com/t/objects-not-found-in-next-code-chunk/97529

@UjjayiniDas 

