### PR TITLE
remove unnecessary deletion of production branch

### DIFF
--- a/.github/workflows/create-production-branch.yml
+++ b/.github/workflows/create-production-branch.yml
@@ -14,8 +14,6 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3
       - run: echo " The ${{ github.repository }} repository has been cloned to the runner."
-      - name: Delete current production branch
-        run: git branch -D production
       - name: Create new production branch
         run: |
           git checkout -b production


### PR DESCRIPTION
In the runner, the production branch is not fetched. So, we do not need to delete the production branch there. The code was attempting to delete the nonexistent production branch which caused an error. This change removes the line that attempted to delete the current production branch.

Instead of removing it locally in the runner, the production branch will just be replaced in the remote repository with the `git push origin production --force-with-lease` line that is already in the code.