### PR TITLE
fix git push error

### DIFF
--- a/.github/workflows/create-production-branch.yml
+++ b/.github/workflows/create-production-branch.yml
@@ -13,6 +13,11 @@ jobs:
       - run: echo "The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - name: Check out repository code
         uses: actions/checkout@v3
+      - name: Set git credentials
+        run: |
+            git config --global user.email "joehoskisson@gmail.com"
+            git config --global user.name "Joe Hoskisson"
+      - run: git branch -D production
       - run: echo " The ${{ github.repository }} repository has been cloned to the runner."
       - run: echo "Create new production branch"
       - run: git checkout -b production
@@ -23,12 +28,8 @@ jobs:
       - run: rm _site.yml
       - run: mv _site/* .
       - run: rm -r _site
-      - name: Set git credentials
-        run: |
-            git config --global user.email "joehoskisson@gmail.com"
-            git config --global user.name "Joe Hoskisson"
       - run: git add .
       - run: git commit -m "build production branch"
       - name: force replacemnt of production branch in remote repository
-        run: git push origin production --force-with-lease
+        run: git push origin production --force
       - run: echo " This job's status is ${{job.status}}."


### PR DESCRIPTION
Fix git push error when creating production branch by forcing the push without lease. This should completely overwrite the production branch. Also, the production branch is deleted in the pipeline environment to start with a fresh branch from main when creating the new production branch.

Fixing error found here: https://github.com/UjjayiniDas/ANTHROPOLOGY_R_TUTORIALS/actions/runs/5347661816/jobs/9696463150

